### PR TITLE
[DEVEX-133] Wrap OpenSSL/EOF errors during Connection#open into Kafka::ConnectionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Changes and additions to the library will be listed here.
 
+## Unreleased
+
+- Wrap `OpenSSL::OpenSSLError` and `EOFError` raised during `Connection#open`
+  into `Kafka::ConnectionError`. Previously an SSL/TLS handshake failure
+  (e.g. peer FIN/RST mid-handshake during an MSK broker heal) escaped
+  `Cluster#fetch_cluster_info`'s seed-broker shuffle loop because its
+  `rescue Error` only catches `Kafka::Error`. The whole consumer would
+  abort even though other seed brokers were healthy. (DEVEX-133)
+
 ## 0.7.10
 
 - Fix logger again (#762)

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -142,6 +142,18 @@ module Kafka
     rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
       @logger.error "Failed to connect to #{self}: #{e}"
       raise ConnectionError, e
+    rescue OpenSSL::OpenSSLError, EOFError => e
+      # SSL/TLS errors that surface during the handshake (peer FIN/RST mid-
+      # handshake, expired or untrusted certificates, etc.) bypass the
+      # connect_timeout machinery in SSLSocketWithTimeout because that
+      # only catches IO::Wait*/EAGAIN. Without this rescue, an SSL error
+      # at one seed broker escapes Cluster#fetch_cluster_info's
+      # `rescue Error` (which only catches Kafka::Error), aborting the
+      # seed-broker fall-through loop. Wrap into Kafka::ConnectionError
+      # so callers see a single, expected exception class for any
+      # "I couldn't connect to this broker" condition.
+      @logger.error "SSL/TLS handshake failed for #{self}: #{e}"
+      raise ConnectionError, e
     end
 
     def idle?

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -113,4 +113,53 @@ describe Kafka::Connection do
       expect(event.payload[:response_size]).to eq 12
     end
   end
+
+  # Regression coverage for the seed-broker fall-through bug: when SSL handshake
+  # fails mid-stream (peer FIN/RST during TLS), OpenSSL::SSL::SSLError used to
+  # escape Connection#open instead of being wrapped into Kafka::ConnectionError.
+  # Cluster#fetch_cluster_info's `rescue Error` only catches Kafka::Error, so
+  # the SSL error escaped the seed-broker shuffle loop, aborting startup even
+  # though other seeds were healthy.
+  describe "SSL handshake failure during #open" do
+    let(:ssl_connection) {
+      Kafka::Connection.new(
+        host: host,
+        port: port,
+        client_id: "test",
+        logger: logger,
+        instrumenter: Kafka::Instrumenter.new(client_id: "test"),
+        connect_timeout: 0.1,
+        socket_timeout: 0.1,
+        ssl_context: OpenSSL::SSL::SSLContext.new,
+      )
+    }
+
+    it "wraps OpenSSL::SSL::SSLError into Kafka::ConnectionError" do
+      allow(Kafka::SSLSocketWithTimeout).to receive(:new).and_raise(
+        OpenSSL::SSL::SSLError, "SSL_connect returned=1 ... unexpected eof while reading",
+      )
+
+      expect {
+        ssl_connection.send_request(double(:request, api_key: 0, encode: nil, response_class: nil))
+      }.to raise_error(Kafka::ConnectionError, /unexpected eof while reading/)
+    end
+
+    it "wraps OpenSSL::X509::CertificateError into Kafka::ConnectionError" do
+      allow(Kafka::SSLSocketWithTimeout).to receive(:new).and_raise(
+        OpenSSL::X509::CertificateError, "certificate verify failed",
+      )
+
+      expect {
+        ssl_connection.send_request(double(:request, api_key: 0, encode: nil, response_class: nil))
+      }.to raise_error(Kafka::ConnectionError, /certificate verify failed/)
+    end
+
+    it "wraps EOFError into Kafka::ConnectionError" do
+      allow(Kafka::SSLSocketWithTimeout).to receive(:new).and_raise(EOFError, "end of file reached")
+
+      expect {
+        ssl_connection.send_request(double(:request, api_key: 0, encode: nil, response_class: nil))
+      }.to raise_error(Kafka::ConnectionError, /end of file reached/)
+    end
+  end
 end


### PR DESCRIPTION
## Context

On 2026-05-07 17:07 PDT, AWS MSK auto-initiated a `HEAL_CLUSTER` operation on `opendoor-kafka-production` to replace an unhealthy broker (b-3). All 8 replicas of `web-kafka-consumer-confluent` went into CrashLoopBackOff for the entire ~70-minute heal window, dropping `web.kafka.consumer.grpc.heartbeat.success` to 0 and paging on-call.

The cluster itself was healthy from MSK's perspective (0 alarms, 0 offline partitions). Only the **consumer startup path** was failing.

## Root cause

`Cluster#fetch_cluster_info` (`lib/kafka/cluster.rb:422`) is INTENDED to shuffle the seed brokers and fall through to the next seed if one fails — that's the documented behavior of `@seed_brokers.shuffle.each do |node|`. But its inner rescue at `cluster.rb:443` is `rescue Error => e`, which only catches `Kafka::Error` and its subclasses.

`OpenSSL::SSL::SSLError < OpenSSL::OpenSSLError < StandardError` — **not** a `Kafka::Error`. So when the shuffle put b-3 (the broker mid-replacement) first and the SSL handshake aborted, the exception escaped the shuffle loop and bubbled all the way to the rake task, killing the pod. Kubernetes restarted it, same shuffle reroll → same failure mode → CrashLoopBackOff.

The real leak is one layer below: `Connection#open` (`lib/kafka/connection.rb:123`) already wraps `Errno::ETIMEDOUT`, `SocketError`, `Errno::ECONNREFUSED`, and `Errno::EHOSTUNREACH` into `Kafka::ConnectionError` — it just forgot the OpenSSL family. This PR plugs that leak. Once Connection#open returns the right exception class, the existing cluster fall-through loop catches it naturally and falls through to the next seed.

## Why `connect_timeout` doesn't help

The errno=107 (`ENOTCONN` on Linux) + "unexpected eof while reading" signature shows the broker actively closed the connection mid-handshake — an **immediate** failure. `SSLSocketWithTimeout` (`lib/kafka/ssl_socket_with_timeout.rb:62-78`) only wraps the SSL handshake in a `select`-based timeout for `Errno::EAGAIN`, `Errno::EWOULDBLOCK`, `IO::WaitReadable`, `IO::WaitWritable`. Any other exception from `connect_nonblock` (including `OpenSSL::SSL::SSLError`) propagates synchronously, regardless of how `connect_timeout` is set.

## Trace

```
INFO -- : Fetching cluster metadata from kafka://b-3...

  OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=107
    state=error: unexpected eof while reading
  .../kafka/ssl_socket_with_timeout.rb:69:in 'OpenSSL::SSL::SSLSocket#connect_nonblock'
  .../kafka/connection.rb:127:in 'Kafka::Connection#open'
  .../kafka/cluster.rb:375:in 'block in Kafka::Cluster#fetch_cluster_info'
  .../kafka/cluster.rb:370:in 'Array#each'
  .../kafka/cluster.rb:370:in 'Kafka::Cluster#fetch_cluster_info'   <-- escapes here
  .../app/consumers/application_consumer.rb:130: ...
  Tasks: TOP => kafka:consume_confluent
```

Smoking gun: only **one** "Fetching cluster metadata from..." log line; no "Failed to fetch metadata from b-3" (which would be `cluster.rb:444` if the rescue had fired); no fall-through to b-1 or b-2.

## The fix

Extend `Connection#open`'s existing rescue list (lib/kafka/connection.rb:139-144) with a third rescue for SSL/EOF errors, wrapping them into `Kafka::ConnectionError` just like the other connect-time failure modes already do:

```ruby
rescue OpenSSL::OpenSSLError, EOFError => e
  @logger.error "SSL/TLS handshake failed for #{self}: #{e}"
  raise ConnectionError, e
```

- `OpenSSL::OpenSSLError` (parent class) covers `SSL::SSLError`, `X509::CertificateError`, and related transient handshake failures.
- `EOFError` covers the rare case where a peer aborts the TCP connection cleanly enough that OpenSSL emits an EOF rather than an SSLError.
- `Kafka::ConnectionError < Kafka::Error`, so the existing `rescue Error => e` at `cluster.rb:443` now catches the wrapped exception and the seed-broker shuffle loop falls through as designed.

## Tests

Added three regression specs in `spec/connection_spec.rb` that stub `Kafka::SSLSocketWithTimeout.new` to raise:
- `OpenSSL::SSL::SSLError`
- `OpenSSL::X509::CertificateError`
- `EOFError`

Each asserts the result wraps to `Kafka::ConnectionError` with the original message preserved.

## Impact / blast radius

- Consumer/producer/admin startup: stops crashing on routine MSK heal events; recovers in milliseconds via the existing fall-through.
- Mid-stream behavior: unchanged — `send_request`'s rescue at `connection.rb:113` continues to handle SystemCallError/EOFError/IOError exactly as before.
- New behavior is strictly additive: the existing 4 rescue branches still fire identically.

## Follow-ups

- After this lands, the `subscribe_with_retry` defense-in-depth in `opendoor-labs/web#55486` becomes redundant for this specific failure mode. We may keep it as a narrower defensive layer or revert it depending on team preference.
- Worth auditing for similar narrow rescues elsewhere in the gem.

Linear: https://linear.app/opendoor/issue/DEVEX-133

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap `OpenSSL::OpenSSLError` and `EOFError` in `Connection#open` into `Kafka::ConnectionError`
> During an AWS MSK broker replacement, SSL handshakes against a partially-up broker raise `OpenSSL::SSL::SSLError` or `EOFError`, which previously escaped `Kafka::Cluster#fetch_cluster_info` and crashed the consumer process.
>
> - Adds a rescue block in [`Connection#open`](https://github.com/opendoor-labs/ruby-kafka/pull/2/files#diff-3926e51cd48c0074a014feb1670dec7317095b573f9c59b69e200096910f3184) that catches `OpenSSL::OpenSSLError` (covering `SSLError` and `CertificateError`) and `EOFError`, logs the failure, and re-raises as `Kafka::ConnectionError`.
> - Adds regression specs in [`spec/connection_spec.rb`](https://github.com/opendoor-labs/ruby-kafka/pull/2/files#diff-a82eb58e3dbed6f29221cf3dec1a91f2dce982fec7c28c448090df1f87f83a5e) covering all three error types propagating from `SSLSocketWithTimeout.new`.
>
> #### 🖇️ Linked Issues
> Partially addresses [DEVEX-133](https://linear.app/opendoor/issue/DEVEX-133): the ticket's root cause was `OpenSSL::SSL::SSLError` escaping as an unhandled exception during consumer startup. This PR fixes the gem-level wrapping so callers catch `Kafka::ConnectionError` consistently; application-level retry logic is a separate follow-up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9e1674.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->