### PR TITLE
[codex] Treat SSL EOF as Kafka connection error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Changes and additions to the library will be listed here.
 
+## Unreleased
+
+- Wrap SSL/TLS connection-open and request IO failures as `Kafka::ConnectionError`
+  so seed-broker fallback can continue when a broker closes during handshake.
+
 ## 0.7.10
 
 - Fix logger again (#762)

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "stringio"
+require "openssl"
 require "kafka/socket_with_timeout"
 require "kafka/ssl_socket_with_timeout"
 require "kafka/protocol/request_message"
@@ -110,7 +111,7 @@ module Kafka
 
         response
       end
-    rescue SystemCallError, EOFError, IOError => e
+    rescue SystemCallError, EOFError, IOError, OpenSSL::OpenSSLError => e
       close
 
       raise ConnectionError, "Connection error #{e.class}: #{e}"
@@ -138,6 +139,11 @@ module Kafka
       @last_request = nil
     rescue Errno::ETIMEDOUT => e
       @logger.error "Timed out while trying to connect to #{self}: #{e}"
+      raise ConnectionError, e
+    rescue OpenSSL::OpenSSLError => e
+      # Treat SSL/TLS handshake failures as connection failures so callers can
+      # fall through to the next seed broker.
+      @logger.error "SSL/TLS error while trying to connect to #{self}: #{e}"
       raise ConnectionError, e
     rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
       @logger.error "Failed to connect to #{self}: #{e}"

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -86,7 +86,10 @@ module Kafka
           raise Errno::ETIMEDOUT
         end
       end
-    rescue
+    rescue StandardError
+      # Explicit class (vs bare `rescue`) for consistency with the nested
+      # cleanup rescue below and to document intent. Bare `rescue` defaults
+      # to StandardError today; making it explicit removes reader doubt.
       begin
         close
       rescue StandardError

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -22,6 +22,9 @@ module Kafka
     # @param ssl_context [OpenSSL::SSL::SSLContext] which SSLContext the ssl connection should use
     # @raise [Errno::ETIMEDOUT] if the timeout is exceeded.
     def initialize(host, port, connect_timeout: nil, timeout: nil, ssl_context:)
+      @tcp_socket = nil
+      @ssl_socket = nil
+
       addr = Socket.getaddrinfo(host, nil)
       sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
 
@@ -83,6 +86,14 @@ module Kafka
           raise Errno::ETIMEDOUT
         end
       end
+    rescue
+      begin
+        close
+      rescue StandardError
+        # Preserve the original connection setup failure; close is best-effort cleanup.
+      end
+
+      raise
     end
 
     # Reads bytes from the socket, possible with a timeout.
@@ -160,12 +171,12 @@ module Kafka
     end
 
     def close
-      @tcp_socket.close
-      @ssl_socket.close
+      @ssl_socket.close if @ssl_socket && !@ssl_socket.closed?
+      @tcp_socket.close if @tcp_socket && !@tcp_socket.closed?
     end
 
     def closed?
-      @tcp_socket.closed? || @ssl_socket.closed?
+      (@tcp_socket.nil? || @tcp_socket.closed?) || (@ssl_socket.nil? || @ssl_socket.closed?)
     end
 
     def set_encoding(encoding)

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -89,4 +89,82 @@ describe Kafka::Cluster do
       }.to raise_exception(Kafka::ConnectionError)
     end
   end
+
+  describe "#add_target_topics" do
+    let(:broker_pool) { double(:broker_pool) }
+    let(:ssl_context) { OpenSSL::SSL::SSLContext.new }
+    let(:sasl_authenticator) { double(:sasl_authenticator) }
+    let(:connection_builder) {
+      Kafka::ConnectionBuilder.new(
+        client_id: "test",
+        logger: LOGGER,
+        instrumenter: Kafka::Instrumenter.new(client_id: "test"),
+        connect_timeout: 0.1,
+        socket_timeout: 0.1,
+        ssl_context: ssl_context,
+        sasl_authenticator: sasl_authenticator,
+      )
+    }
+    let(:bad_broker) {
+      Kafka::Broker.new(
+        connection_builder: connection_builder,
+        host: "bad-broker",
+        port: 9096,
+        logger: LOGGER,
+      )
+    }
+    let(:good_broker) { double(:good_broker, disconnect: nil) }
+    let(:seed_brokers) {
+      [
+        URI("kafka://bad-broker:9096"),
+        URI("kafka://good-broker:9096"),
+      ]
+    }
+
+    let(:cluster) {
+      Kafka::Cluster.new(
+        seed_brokers: seed_brokers,
+        broker_pool: broker_pool,
+        logger: LOGGER,
+      )
+    }
+
+    let(:metadata) {
+      Kafka::Protocol::MetadataResponse.new(
+        brokers: [
+          Kafka::BrokerInfo.new(
+            node_id: 42,
+            host: "good-broker",
+            port: 9096,
+          )
+        ],
+        controller_id: 42,
+        topics: [],
+      )
+    }
+
+    before do
+      allow(seed_brokers).to receive(:shuffle).and_return(seed_brokers.dup)
+      allow(sasl_authenticator).to receive(:authenticate!) do |connection|
+        connection.send_request(Kafka::Protocol::SaslHandshakeRequest.new("PLAIN"))
+      end
+      allow(good_broker).to receive(:fetch_metadata).and_return(metadata)
+    end
+
+    it "falls through to the next seed broker when SSL handshake fails during metadata refresh" do
+      expect(Kafka::SSLSocketWithTimeout).to receive(:new).with(
+        "bad-broker",
+        9096,
+        connect_timeout: 0.1,
+        timeout: 0.1,
+        ssl_context: ssl_context,
+      ).and_raise(OpenSSL::SSL::SSLError, "unexpected eof while reading")
+      expect(broker_pool).to receive(:connect).with("bad-broker", 9096).ordered.and_return(bad_broker)
+      expect(broker_pool).to receive(:connect).with("good-broker", 9096).ordered.and_return(good_broker)
+
+      expect {
+        cluster.add_target_topics(["greetings"])
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -144,10 +144,19 @@ describe Kafka::Cluster do
     }
 
     before do
-      allow(seed_brokers).to receive(:shuffle).and_return(seed_brokers.dup)
+      # Block form (not `.and_return(seed_brokers.dup)`) so each invocation
+      # gets a fresh dup — defends against a future Cluster change that
+      # calls shuffle more than once per metadata refresh.
+      allow(seed_brokers).to receive(:shuffle) { seed_brokers.dup }
+
+      # Load-bearing: the SASL authenticate! stub calls send_request, which
+      # forces ConnectionBuilder to actually open the socket. Without this,
+      # the SSLSocketWithTimeout stub below would never fire and we wouldn't
+      # be exercising the real Connection -> SSL handshake path. Don't remove.
       allow(sasl_authenticator).to receive(:authenticate!) do |connection|
         connection.send_request(Kafka::Protocol::SaslHandshakeRequest.new("PLAIN"))
       end
+
       allow(good_broker).to receive(:fetch_metadata).and_return(metadata)
     end
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -7,6 +7,7 @@ describe Kafka::Connection do
   let(:host) { "127.0.0.1" }
   let(:server) { TCPServer.new(host, 0) }
   let(:port) { server.addr[1] }
+  let(:ssl_context) { nil }
 
   let(:connection) {
     Kafka::Connection.new(
@@ -17,6 +18,7 @@ describe Kafka::Connection do
       instrumenter: Kafka::Instrumenter.new(client_id: "test"),
       connect_timeout: 0.1,
       socket_timeout: 0.1,
+      ssl_context: ssl_context,
     )
   }
 
@@ -72,6 +74,49 @@ describe Kafka::Connection do
       expect {
         connection.send_request(request)
       }.to raise_error(Kafka::ConnectionError)
+    end
+
+    it "disconnects on SSL errors during request IO" do
+      allow(connection).to receive(:write_request).and_raise(
+        OpenSSL::SSL::SSLError,
+        "tls alert",
+      )
+
+      expect(connection).to receive(:close).and_call_original
+
+      expect {
+        connection.send_request(request)
+      }.to raise_error(Kafka::ConnectionError, /tls alert/)
+    end
+
+    context "when SSL connection setup fails" do
+      let(:ssl_context) { OpenSSL::SSL::SSLContext.new }
+
+      def expect_ssl_setup_error_wrapped(error_class, message)
+        allow(Kafka::SSLSocketWithTimeout).to receive(:new).and_raise(
+          error_class,
+          message,
+        )
+
+        expect {
+          connection.send_request(request)
+        }.to raise_error(Kafka::ConnectionError, /#{Regexp.escape(message)}/)
+      end
+
+      it "wraps SSL errors in a connection error" do
+        expect_ssl_setup_error_wrapped(
+          OpenSSL::SSL::SSLError,
+          "unexpected eof while reading",
+        )
+      end
+
+      it "wraps certificate errors in a connection error" do
+        expect_ssl_setup_error_wrapped(
+          OpenSSL::X509::CertificateError,
+          "certificate verify failed",
+        )
+      end
+
     end
 
     it "re-opens the connection after a network error" do

--- a/spec/ssl_socket_with_timeout_spec.rb
+++ b/spec/ssl_socket_with_timeout_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe Kafka::SSLSocketWithTimeout, ".open" do
+  let(:ssl_context) { OpenSSL::SSL::SSLContext.new }
+
   it "times out if the server doesn't accept the connection within the timeout" do
     host = "172.16.0.0" # this address is non-routable!
     port = 4444
@@ -17,5 +19,37 @@ describe Kafka::SSLSocketWithTimeout, ".open" do
     finish = Time.now
 
     expect(finish - start).to be < allowed_time
+  end
+
+  it "closes sockets when SSL handshake setup fails" do
+    tcp_socket = double(:tcp_socket)
+    ssl_socket = double(:ssl_socket)
+
+    allow(Socket).to receive(:getaddrinfo).and_return([["AF_INET", nil, nil, "127.0.0.1"]])
+    allow(Socket).to receive(:pack_sockaddr_in).and_return("sockaddr")
+    allow(Socket).to receive(:new).and_return(tcp_socket)
+    allow(tcp_socket).to receive(:setsockopt)
+    allow(tcp_socket).to receive(:connect_nonblock).and_return(0)
+    allow(tcp_socket).to receive(:closed?).and_return(false)
+    expect(tcp_socket).to receive(:close)
+
+    allow(OpenSSL::SSL::SSLSocket).to receive(:new).with(tcp_socket, ssl_context).and_return(ssl_socket)
+    allow(ssl_socket).to receive(:hostname=)
+    allow(ssl_socket).to receive(:connect_nonblock).and_raise(
+      OpenSSL::SSL::SSLError,
+      "unexpected eof while reading",
+    )
+    allow(ssl_socket).to receive(:closed?).and_return(false)
+    expect(ssl_socket).to receive(:close)
+
+    expect {
+      Kafka::SSLSocketWithTimeout.new(
+        "broker.example.com",
+        9096,
+        connect_timeout: 0.1,
+        timeout: 1,
+        ssl_context: ssl_context,
+      )
+    }.to raise_error(OpenSSL::SSL::SSLError, /unexpected eof while reading/)
   end
 end


### PR DESCRIPTION
## Summary
- wrap OpenSSL connection-open and request IO failures as Kafka::ConnectionError
- close partially-open SSL sockets when handshake setup fails
- cover SSL handshake EOF, certificate errors, mid-request SSL errors, and seed-broker metadata fallback
- add an Unreleased changelog entry

## Why
MSK can close a broker connection during SSL handshake, raising OpenSSL::SSL::SSLError immediately instead of timing out. That raw exception bypassed Cluster#fetch_cluster_info seed-broker fallback because the loop only rescues Kafka::Error. Normalizing OpenSSL failures to Kafka::ConnectionError lets the existing fallback path try the next seed broker.

The rescue uses OpenSSL::OpenSSLError rather than only OpenSSL::SSL::SSLError so related OpenSSL failures, including certificate errors during connection open or request IO, are also classified as broker connection failures. Existing send_request EOFError handling is preserved for request IO failures.

SSLSocketWithTimeout now cleans up partially-open sockets when initialization fails, so recovering from a bad seed broker does not leave failed handshake sockets waiting for GC.

## Validation
- ruby -c lib/kafka/ssl_socket_with_timeout.rb && ruby -c lib/kafka/connection.rb && ruby -c spec/connection_spec.rb && ruby -c spec/ssl_socket_with_timeout_spec.rb && ruby -c spec/cluster_spec.rb
- focused RSpec without Bundler, because local bundle install fails building ffi under the system Ruby: 14 examples, 0 failures

The cluster regression now stubs SSLSocketWithTimeout.new to raise raw OpenSSL::SSL::SSLError through the real ConnectionBuilder/Broker path before verifying Cluster#fetch_cluster_info falls through to the next seed broker.